### PR TITLE
[1.21] Fix nerfBowMultishot & Pillagers

### DIFF
--- a/1.21/src/main/java/top/offsetmonkey538/bettermultishot/mixin/item/RangedWeaponItemMixin.java
+++ b/1.21/src/main/java/top/offsetmonkey538/bettermultishot/mixin/item/RangedWeaponItemMixin.java
@@ -55,14 +55,14 @@ public abstract class RangedWeaponItemMixin {
             @Local int projectileIndex
     ) {
         if (!(entity instanceof ProjectileEntity projectile)) return false;
-        if (!(shooter instanceof PlayerEntity player)) return false;
+        if (!(shooter instanceof PlayerEntity player)) return original.call(instance, entity);
 
         if (projectileIndex <= 0) return original.call(instance, entity);
 
 
         if (projectile instanceof PersistentProjectileEntity persistent) persistent.pickupType = PersistentProjectileEntity.PickupPermission.CREATIVE_ONLY;
         ((ProjectileEntityAccess) projectile).bettermultishot$setFromMultishot(true);
-
+        if (projectile instanceof PersistentProjectileEntity arrow && config.nerfBowMultishot) arrow.setDamage(arrow.getDamage() / 2);
 
         projectile = config.shootingPattern.newProjectile(
                 projectiles.size(),


### PR DESCRIPTION
Fixed `nerfBowMultishot` not working in 1.21 and Pillagers crossbows not shooting arrows.